### PR TITLE
Fixed duplicate & in piwik data collection endpoint url

### DIFF
--- a/piwikpro-gtm-serverside-ga4.tpl
+++ b/piwikpro-gtm-serverside-ga4.tpl
@@ -355,7 +355,7 @@ const buildRequest = (eventData) => {
   const lang = eventData.hasOwnProperty('lang') ? '&lang=' + encodeUriComponent(eventData.lang) : '';
   let requestPath = requestEndpoint + '?' +
         'rec=1' + '&' +
-        'idsite=' + encodeUriComponent(data.siteID) + '&' +
+        'idsite=' + encodeUriComponent(data.siteID) +
         page_location +
         ip_override +
         user_agent +


### PR DESCRIPTION
Great server tag!

While testing it out I noticed what seems to be a duplicate `&` in the piwik data collection endpoint?

`https://{account}.piwik.pro/ppms.php?rec=1&idsite={websiteid}&&url={url}&cip=...`

This PR might fix it :)